### PR TITLE
Be consistent with the upper-case of 'Httplug'

### DIFF
--- a/docs/httplug.md
+++ b/docs/httplug.md
@@ -22,7 +22,7 @@ Note: Until Httplug 1.0 becomes stable, we will focus on the Guzzle6 adapter.
 
 When writing an application, you need to require a concrete [client implementation](https://packagist.org/providers/php-http/client-implementation).
 
-See [virtual package](virtual-package.md) for more information on the topic of working with HTTPlug implementations.
+See [virtual package](virtual-package.md) for more information on the topic of working with Httplug implementations.
 
 
 ## Installation in a reusable package

--- a/docs/virtual-package.md
+++ b/docs/virtual-package.md
@@ -5,7 +5,7 @@ Virtual packages are a way to specify the dependency on an implementation of an 
 There is no project registered with that name. However, all client implementations including client adapters for Httplug use the `provide` section to tell composer that they do provide the client-implementation.
 
 
-# Using a Library that depends on HTTPlug
+# Using a Library that depends on Httplug
 
 Reusable libraries do not depend on a concrete implementation but only on the virtual package `php-http/client-implementation`. This is to avoid hard coupling and allows the user of the library to choose the implementation. You can think of this as an "interface" or "contract" for packages.
 


### PR DESCRIPTION
We have written Httplug almost everywhere. This small PR makes sure we are consistent. 