### PR TITLE
start list of framework integrations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,12 @@ PHP-HTTP is separated into several packages:
 
 See [package overview](package-overview.md) for a complete list.
 
+### Framework Integration
+
+Httplug can be used in any PHP based project. Nonetheless, we provide particular integration for some popular frameworks:
+
+- [HttplugBundle](https://github.com/php-http/HttplugBundle/) integration with the Symfony framework.
+
 
 ## History
 


### PR DESCRIPTION
for framework integrations, i suggest that we just link to the repository and document the integrations there rather than in the documentation. the documentation should not be about framework specific tool imho, to keep things easier to understand.