### PR TITLE
Minor fixes to headers documentation

### DIFF
--- a/plugins/headers.rst
+++ b/plugins/headers.rst
@@ -6,7 +6,7 @@ Header plugins are useful to manage request headers. Many operations are possibl
 Default headers values
 ----------------------
 
-The plugin ``HeaderDefaultPlugin`` allows to set default values for given headers.
+The plugin ``HeaderDefaultsPlugin`` allows to set default values for given headers.
 That means if a header is not set, it will be added.
 However, if the header already is present, the request is left unchanged.
 
@@ -14,17 +14,17 @@ However, if the header already is present, the request is left unchanged.
 
     use Http\Discovery\HttpClientDiscovery;
     use Http\Client\Common\PluginClient;
-    use Http\Client\Common\Plugin\HeaderDefaultPlugin;
+    use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 
     $defaultUserAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1';
 
-    $headerDefaultPlugin = new HeaderDefaultPlugin([
+    $headerDefaultsPlugin = new HeaderDefaultsPlugin([
         'User-Agent' => $defaultUserAgent
     ]);
 
     $pluginClient = new PluginClient(
         HttpClientDiscovery::find(),
-        [$headerDefaultPlugin]
+        [$headerDefaultsPlugin]
     );
 
 Mandatory headers values

--- a/plugins/headers.rst
+++ b/plugins/headers.rst
@@ -6,9 +6,9 @@ Header plugins are useful to manage request headers. Many operations are possibl
 Default headers values
 ----------------------
 
-The plugin ``HeaderDefaultsPlugin`` allows to set default values for given headers.
+The plugin ``HeaderDefaultsPlugin`` allows you to set default values for given headers.
 That means if a header is not set, it will be added.
-However, if the header already is present, the request is left unchanged.
+However, if the header is already present, the request is left unchanged.
 
 .. code:: php
 
@@ -30,8 +30,8 @@ However, if the header already is present, the request is left unchanged.
 Mandatory headers values
 ------------------------
 
-The plugin ``HeaderSetPlugin`` allows to fix values of given header. That means that any request passing through
-this plugin will have the given value for given header.
+The plugin ``HeaderSetPlugin`` allows you to fix values of given headers. That means that any request passing through
+this plugin will have the given value for the given header.
 
 .. code:: php
 
@@ -56,7 +56,7 @@ this plugin will have the given value for given header.
 Removing headers
 ----------------
 
-The plugin ``HeaderRemovePlugin`` allows to remove given headers from the request.
+The plugin ``HeaderRemovePlugin`` allows you to remove given headers from the request.
 
 .. code:: php
 
@@ -79,7 +79,7 @@ The plugin ``HeaderRemovePlugin`` allows to remove given headers from the reques
 Appending header values
 -----------------------
 
-The plugin ``HeaderAppendPlugin`` allows to set headers or to add values to existing headers.
+The plugin ``HeaderAppendPlugin`` allows you to set headers or to add values to existing headers.
 That means if the request already has the given headers then the value will be appended to the current value
 but if the request does not already have the given header, it will be added to the request with the given value.
 
@@ -108,10 +108,10 @@ but if the request does not already have the given header, it will be added to t
 Mixing operations
 -----------------
 
-Different header plugins can be mixed to achieve different behaviors
+Different header plugins can be mixed together to achieve different behaviors
 and you can use the same plugin for identical operations.
 
-The following example will force the ``User-Agent`` and the ``Accept`` header values while removing ``Cookie`` header:
+The following example will force the ``User-Agent`` and the ``Accept`` header values while removing the ``Cookie`` header:
 
 .. code:: php
 


### PR DESCRIPTION
Mostly grammar, but also corrected name of the default headers plugin.