### PR TITLE
Added docker image to easier build documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@ FROM  debian:latest
 
 # Credit goes to https://github.com/headstar/sphinx-doc-docker
 
-RUN   apt-get update
+RUN apt-get update
 
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y enchant
-RUN   apt-get update --fix-missing
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y enchant
+RUN apt-get update --fix-missing
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git
 
-RUN   pip install Sphinx==1.4
-RUN   pip install sphinx_rtd_theme
-RUN   pip install alabaster
-RUN   pip install sphinx_bootstrap_theme
+RUN pip install Sphinx==1.4
+RUN pip install sphinx_rtd_theme
+RUN pip install alabaster
+RUN pip install sphinx_bootstrap_theme
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM  debian:latest
+
+# Credit goes to https://github.com/headstar/sphinx-doc-docker
+
+RUN   apt-get update
+
+RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
+RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y enchant
+RUN   apt-get update --fix-missing
+RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y git
+
+RUN   pip install Sphinx==1.4
+RUN   pip install sphinx_rtd_theme
+RUN   pip install alabaster
+RUN   pip install sphinx_bootstrap_theme
+
+CMD ["/bin/bash"]

--- a/development/documentation.rst
+++ b/development/documentation.rst
@@ -1,8 +1,33 @@
 Building the Documentation
---------------------------
+==========================
 
-First `install Sphinx`_ and `install enchant`_ (e.g. ``sudo apt-get install enchant``),
-then download the requirements:
+We build the documentation with Sphinx. You could install it on your system or use Docker.
+
+Install Sphinx
+--------------
+
+Install on local machine
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The installation for Sphinx differs between system. See `Sphinx installation page`_ for details. When Sphinx is
+installed you need to `install enchant`_ (e.g. ``sudo apt-get install enchant``).
+
+Using Docker
+~~~~~~~~~~~~
+
+If you are using docker. Run the following commands from the repository root.
+
+.. code-block:: bash
+
+    $ docker build -t sphinx-doc .
+    $ docker run -i -t -v /absolute/path/to/repo/root:/doc sphinx-doc
+    $ # You are now in the docker image
+    $ cd doc
+
+Build documentation
+-------------------
+
+Before we can build the documentation we have to make sure to install all requirements.
 
 .. code-block:: bash
 
@@ -15,6 +40,6 @@ To build the docs:
     $ make html
     $ make spelling
 
-.. _install Sphinx: http://sphinx-doc.org/latest/install.html
+.. _Sphinx installation page: http://sphinx-doc.org/latest/install.html
 .. _install enchant: http://www.abisource.com/projects/enchant/
 


### PR DESCRIPTION
I cant install Sphinx on my OSX. I use the docker image. It would make it easier for others to get started if we included this. 

What do you think?