### PR TITLE
Be more friendly to third party users

### DIFF
--- a/httplug/users.rst
+++ b/httplug/users.rst
@@ -5,20 +5,17 @@ If you use a library that depends on HTTPlug (say, ``some/awesome-library``),
 you need to include an HTTPlug client in your project before you can include
 ``awesome-library``.
 
-From the list of :doc:`clients </clients>`, choose on that best fits your
-application, then include it in your project. For instance, if you decide to
-use the Socket client:
+First you need to choose library to send HTTP messages and that also provide the virtual package
+`php-http/client-implementation`_. In the example
+below we are using cURL.
+
+.. note::
+
+    Read about the clients and adapters provided by the php-http organisation at :doc:`this page </clients>`.
 
 .. code-block:: bash
 
-    $ composer require php-http/socket-client
-
-Instead of an HTTPlug client, you may want to use an adapter for your favorite
-HTTP client. If that turns out to be Guzzle:
-
-.. code-block:: bash
-
-    $ composer require php-http/guzzle6-adapter
+    $ composer require php-http/curl-client
 
 Then you can include the library:
 
@@ -26,10 +23,24 @@ Then you can include the library:
 
     $ composer require some/awesome-library
 
+Secondly you need to install a library that implements PSR-7 and a library containing message factories. The majority
+of users installs Zend's Diactoros or Guzzle's PSR-7. Do one of the following:
+
+.. code-block:: bash
+
+    $ composer require php-http/message zendframework/zend-diactoros
+
+.. code-block:: bash
+
+    $ composer require php-http/message guzzlehttp/psr7
+
 Troubleshooting
 ---------------
 
-If you try to include the HTTPlug-dependent library before you have included a
+Composer fails
+``````````````
+
+If you try to include the HTTPlug dependent library before you have included a
 HTTP client in your project, Composer will throw an error:
 
 .. code-block:: none
@@ -44,6 +55,20 @@ HTTP client in your project, Composer will throw an error:
 
 You can solve this by including a HTTP client or adapter, as described above.
 
+No  message factories
+`````````````````````
+
+You may get an exception telling you that "No message factories found", this means that either you have not installed a
+PSR-7 implementation or that there is no factories installed to create HTTP messages.
+
+.. code-block:: none
+
+    No message factories found. To use Guzzle or Diactoros factories install php-http/message and
+    the chosen message implementation.
+
+
+You can solve this by including ``php-http/message`` and ``zendframework/zend-diactoros``, as descibed above.
+
 Background
 ----------
 
@@ -51,6 +76,7 @@ Reusable libraries do not depend on a concrete implementation but only on the vi
 ``php-http/client-implementation``. This is to avoid hard coupling and allows the user of the
 library to choose the implementation. You can think of this as an "interface" or "contract" for packages.
 
-When *using a reusable library* in an application, one must ``require`` a concrete implementation.
-Make sure the ``require`` section includes a package that provides ``php-http/client-implementation``.
-Failing to do that will lead to composer reporting this error:
+The reusable libraries have no hard coupling to the PSR-7 implementation either which gives you the flexibility to
+choose an implementation yourself.
+
+.. _`php-http/client-implementation`: https://packagist.org/providers/php-http/client-implementation

--- a/httplug/users.rst
+++ b/httplug/users.rst
@@ -11,7 +11,7 @@ below we are using cURL.
 
 .. note::
 
-    Read about the clients and adapters provided by the php-http organisation at :doc:`this page </clients>`.
+    Read about the clients and adapters provided by the PHP-HTTP organization at :doc:`this page </clients>`.
 
 .. code-block:: bash
 
@@ -67,7 +67,7 @@ PSR-7 implementation or that there is no factories installed to create HTTP mess
     the chosen message implementation.
 
 
-You can solve this by including ``php-http/message`` and ``zendframework/zend-diactoros``, as descibed above.
+You can solve this by including ``php-http/message`` and ``zendframework/zend-diactoros``, as described above.
 
 Background
 ----------

--- a/spelling_word_list.txt
+++ b/spelling_word_list.txt
@@ -30,3 +30,4 @@ username
 whitelist
 wiki
 workflow
+Zend


### PR DESCRIPTION
I would like this page to be a page that third party libraries can link to and all necessary information for their users is on that page. 

This page should also be written in a very basic way. 