### PR TITLE
Added more options examples

### DIFF
--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -62,16 +62,16 @@ cache control headers are not cached. If you want a default cache lifetime if th
         'default_ttl' => 42, // cache lifetime time in seconds
     ];
 
-If you tell the plugin to completely ignore the cache control headers from the server and force caching the response
-for the default time to life. The options below will cache all responses for one hour::
+You can tell the plugin to completely ignore the cache control headers from the server and force caching the response
+for the default time to live. The options below will cache all responses for one hour::
 
     $options = [
         'default_ttl' => 3600, // cache for one hour
         'respect_cache_headers' => false,
     ];
 
-Be ware of null values
-``````````````````````
+Semantics of null values
+````````````````````````
 
 Setting null to the options ``cache_lifetime`` or ``default_ttl`` means "Store this as long as you can (forever)".
 This could be a great thing when you requesting a pay-per-request API (eg. GoogleTranslate).
@@ -94,13 +94,13 @@ Ask the server if the response is valid at most ever hour. Store the cache item 
     ];
 
 
-Ask the server if the response is valid at most ever hour. If the response has not been used within 30 days it will be
+Ask the server if the response is valid at most ever hour. If the response has not been used within one year it will be
 removed from the cache::
 
     $options = [
         'default_ttl' => 3600,
         'respect_cache_headers' => false,
-        'cache_lifetime' => 86400*30, // 30 days
+        'cache_lifetime' => 86400*365, // one year
     ];
 
 

--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -53,7 +53,7 @@ configure. Their default values and meaning is described by the table below.
 
     A HTTP response may have expired but it is still in cache. If so, headers like ``If-Modified-Since`` and
     ``If-None-Match`` are added to the HTTP request to allow the server answer with 304 status code. When
-    a 304 response is recieved we update the CacheItem and save it again for at least ``cache_lifetime``.
+    a 304 response is received we update the CacheItem and save it again for at least ``cache_lifetime``.
 
 Using these options together you may control the how your cached responses behave. By default, responses with no
 cache control headers are not cached. If you want a default cache lifetime if the server specifies no ``max-age``, use::

--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -55,7 +55,7 @@ configure. Their default values and meaning is described by the table below.
     ``If-None-Match`` are added to the HTTP request to allow the server answer with 304 status code. When
     a 304 response is received we update the CacheItem and save it again for at least ``cache_lifetime``.
 
-Using these options together you may control the how your cached responses behave. By default, responses with no
+Using these options together you can control how your responses should be cached. By default, responses with no
 cache control headers are not cached. If you want a default cache lifetime if the server specifies no ``max-age``, use::
 
     $options = [

--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -42,7 +42,7 @@ configure. Their default values and meaning is described by the table below.
 +---------------------------+---------------+------------------------------------------------------+
 | Name                      | Default value | Description                                          |
 +===========================+===============+======================================================+
-| ``default_ttl``           | ``null``      | The default max age of a Response                    |
+| ``default_ttl``           | ``0``      | The default max age of a Response                    |
 +---------------------------+---------------+------------------------------------------------------+
 | ``respect_cache_headers`` | ``true``      | Whatever or not we should care about cache headers   |
 +---------------------------+---------------+------------------------------------------------------+
@@ -74,7 +74,7 @@ Semantics of null values
 ````````````````````````
 
 Setting null to the options ``cache_lifetime`` or ``default_ttl`` means "Store this as long as you can (forever)".
-This could be a great thing when you requesting a pay-per-request API (eg. GoogleTranslate).
+This could be a great thing when you requesting a pay-per-request API (e.g. GoogleTranslate).
 
 Store a response as long the cache implementation allows::
 

--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -42,7 +42,7 @@ configure. Their default values and meaning is described by the table below.
 +---------------------------+---------------+------------------------------------------------------+
 | Name                      | Default value | Description                                          |
 +===========================+===============+======================================================+
-| ``default_ttl``           | ``0``      | The default max age of a Response                    |
+| ``default_ttl``           | ``0``         | The default max age of a Response                    |
 +---------------------------+---------------+------------------------------------------------------+
 | ``respect_cache_headers`` | ``true``      | Whatever or not we should care about cache headers   |
 +---------------------------+---------------+------------------------------------------------------+

--- a/spelling_word_list.txt
+++ b/spelling_word_list.txt
@@ -6,7 +6,6 @@ callables
 cURL
 Diactoros
 Elasticsearch
-eg
 fallback
 GitHub
 hotfix

--- a/spelling_word_list.txt
+++ b/spelling_word_list.txt
@@ -6,6 +6,7 @@ callables
 cURL
 Diactoros
 Elasticsearch
+eg
 fallback
 GitHub
 hotfix


### PR DESCRIPTION
This will hopefully clear out some confusions about how long the cache item and responses are stored.

Related to: https://github.com/php-http/cache-plugin/issues/19