### PR TITLE
mention framework integration in users intro

### DIFF
--- a/httplug/users.rst
+++ b/httplug/users.rst
@@ -13,6 +13,9 @@ you plan to use:
 
     composer require php-http/curl-client guzzlehttp/psr7 php-http/message
 
+If you use a framework, check the :doc:`integrations <../integrations/index>`
+overview to see if there is a plugin for your framework.
+
 Details
 -------
 


### PR DESCRIPTION
i think we should point library users to the framework integrations. for now there is only the symfony bundle documented, but other integrations might happen in the future...