### PR TITLE
Improve the wording of the link to the PluginClient doc

### DIFF
--- a/components/client-common.rst
+++ b/components/client-common.rst
@@ -80,7 +80,7 @@ If one or more of the requests throw exceptions, they are added to the
 PluginClient
 ------------
 
-See :doc:`/plugins/introduction`
+See :doc:`the documentation about plugins </plugins/introduction>`
 
 HttpClientPool
 --------------


### PR DESCRIPTION
this is better than the current ``See Introduction``