### PR TITLE
Suggest latest version of the mock client

### DIFF
--- a/httplug/library-developers.rst
+++ b/httplug/library-developers.rst
@@ -53,7 +53,7 @@ in the ``require-dev`` section in your library’s ``composer.json``. You could 
             "php-http/client-implementation": "^1.0"
         },
         "require-dev": {
-            "php-http/mock-client": "^0.3"
+            "php-http/mock-client": "^1.0"
         }
     }
 


### PR DESCRIPTION
The mock client stable first stable version has been released, and
should be used because otherwise tests would be run with old versions of
the php-http libraries.