### PR TITLE
docutil should be locked at 0.12 to get successful build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx~=1.4.0
 sphinx-rtd-theme==0.1.6
 sphinxcontrib-spelling
 pyenchant
+docutils==0.12


### PR DESCRIPTION
When the documentation is build with docutil 0.13.1, the following error occurs:
```
# Sphinx version: 1.4.9
# Python version: 2.7.13 (CPython)
# Docutils version: 0.13.1 release
# Jinja2 version: 2.9.6
# Last messages:
#   writing output... [ 48%] php-http/documentation/lib/python2.7/site-packages/Jinja2-2.9.6.dist-info/DESCRIPTION
#   writing output... [ 50%] php-http/documentation/lib/python2.7/site-packages/MarkupSafe-1.0.dist-info/DESCRIPTION
#   writing output... [ 51%] php-http/documentation/lib/python2.7/site-packages/Pygments-2.2.0.dist-info/DESCRIPTION
#   writing output... [ 52%] php-http/documentation/lib/python2.7/site-packages/Sphinx-1.4.9.dist-info/DESCRIPTION
#   writing output... [ 54%] php-http/documentation/lib/python2.7/site-packages/alabaster-0.7.10.dist-info/DESCRIPTION
#   writing output... [ 55%] php-http/documentation/lib/python2.7/site-packages/appdirs-1.4.3.dist-info/DESCRIPTION
#   writing output... [ 56%] php-http/documentation/lib/python2.7/site-packages/docutils-0.13.1.dist-info/DESCRIPTION
#   writing output... [ 58%] php-http/documentation/lib/python2.7/site-packages/imagesize-0.7.1.dist-info/DESCRIPTION
#   writing output... [ 59%] php-http/documentation/lib/python2.7/site-packages/packaging-16.8.dist-info/DESCRIPTION
#   writing output... [ 61%] php-http/documentation/lib/python2.7/site-packages/pip-9.0.1.dist-info/DESCRIPTION
# Loaded extensions:
#   sphinxcontrib.spelling (unknown version) from /home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinxcontrib/spelling/__init__.pyc
#   alabaster (0.7.10) from /home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/alabaster/__init__.pyc
Traceback (most recent call last):
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/cmdline.py", line 244, in main
    app.build(opts.force_all, filenames)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/application.py", line 297, in build
    self.builder.build_update()
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 251, in build_update
    'out of date' % len(to_build))
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 322, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 360, in write
    self._write_serial(sorted(docnames), warnings)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 368, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/builders/html.py", line 448, in write_doc
    self.docwriter.write(doctree, destination)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/docutils/writers/__init__.py", line 80, in write
    self.translate()
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/sphinx/writers/html.py", line 47, in translate
    self.document.walkabout(visitor)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/docutils/nodes.py", line 187, in walkabout
    visitor.dispatch_departure(self)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/docutils/nodes.py", line 1895, in dispatch_departure
    return method(node)
  File "/home/fabien/Projets/php-http/documentation/php-http/documentation/lib/python2.7/site-packages/docutils/writers/_html_base.py", line 671, in depart_document
    assert not self.context, 'len(context) = %s' % len(self.context)
AssertionError: len(context) = 3
```

According to https://github.com/sphinx-doc/sphinx/issues/3212, locking docutil to 0.12 fixes the issue.