### PR TITLE
Add CakePHP adapter documentation. Fixes #155

### DIFF
--- a/clients/cakephp-adapter.rst
+++ b/clients/cakephp-adapter.rst
@@ -1,7 +1,7 @@
 CakePHP Adapter
 ===============
 
-An HTTPlug adapter for the CakePHP HTTP client.
+An HTTPlug adapter for the `CakePHP HTTP client`_.
 
 Installation
 ------------
@@ -20,4 +20,39 @@ not yet included in your project), run:
 Usage
 -----
 
-To be written...
+Begin by creating a CakePHP HTTP client, passing any configuration parameters you
+like::
+
+    use Cake\Http\Client as CakeClient;
+
+    $config = [
+        // Config params
+    ];
+    $cakeClient = new CakeClient($config);
+
+Then create the adapter::
+
+    use Http\Adapter\Cake\Client as CakeAdapter;
+    use Http\Message\MessageFactory\GuzzleMessageFactory;
+
+    $adapter = new CakeAdapter($cakeClient, new GuzzleMessageFactory());
+
+.. note::
+
+    The client parameter is optional; if you do not supply it (or set it to
+    ``null``) the adapter will create a default CakePHP HTTP client without any options.
+
+
+Or if you installed the :doc:`discovery </discovery>` layer::
+
+    use Http\Adapter\Cake\Client as CakeAdapter;
+
+    $adapter = new CakeAdapter($cakeClient);
+
+.. warning::
+
+    The message factory parameter is mandatory if the discovery layer is not installed.
+
+.. include:: includes/further-reading-sync.inc
+
+.. _CakePHP HTTP client: https://book.cakephp.org/3.0/en/core-libraries/httpclient.html


### PR DESCRIPTION
I came across this great project and saw the CakePHP adapter was released just a short while ago as 0.1.

As we plan on using it in a project and the documentation had a big TODO, I wrote a bit of it. It is mainly a copy-paste of the Guzzle5 docs, but adapted for the CakePHP adapter.