### PR TITLE
Replaces deprecated getMock with createMock in mock client documentation

### DIFF
--- a/clients/mock-client.rst
+++ b/clients/mock-client.rst
@@ -61,7 +61,7 @@ certain responses::
         {
             $client = new Client();
 
-            $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+            $response = $this->createMock('Psr\Http\Message\ResponseInterface');
             $client->addResponse($response);
 
             // $request is an instance of Psr\Http\Message\RequestInterface
@@ -81,7 +81,7 @@ Or set a default response::
         {
             $client = new Client();
 
-            $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+            $response = $this->createMock('Psr\Http\Message\ResponseInterface');
             $client->setDefaultResponse($response);
 
             // $firstRequest and $secondRequest are instances of Psr\Http\Message\RequestInterface
@@ -129,7 +129,7 @@ Or set a default exception::
             $exception = new \Exception('Whoops!');
             $client->setDefaultException($exception);
 
-            $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+            $response = $this->createMock('Psr\Http\Message\ResponseInterface');
             $client->addResponse($response);
 
             // $firstRequest and $secondRequest are instances of Psr\Http\Message\RequestInterface


### PR DESCRIPTION
As of PHPUnit 5.4.0 (released more than a year ago) `getMock` has been deprecated, `createMock` is the correct method to use.

https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0