### PR TITLE
lock spelling on version that works

### DIFF
--- a/integrations/symfony-bundle.rst
+++ b/integrations/symfony-bundle.rst
@@ -309,7 +309,7 @@ service names follow the pattern ``httplug.plugin.<name>``:
 
 To use a custom plugin or when you need specific configuration that is not
 covered by the bundle configuration, you can configure the plugin as a normal
-symfony service and then reference that service name in the plugin list of your
+Symfony service and then reference that service name in the plugin list of your
 client:
 
 .. code-block:: yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/fabpot/sphinx-php.git
 sphinx~=1.4.0
 sphinx-rtd-theme==0.1.6
-sphinxcontrib-spelling
+sphinxcontrib-spelling==4.2.0
 pyenchant
 docutils==0.12

--- a/spelling_word_list.txt
+++ b/spelling_word_list.txt
@@ -1,6 +1,7 @@
 Artax
 async
 auth
+autowiring
 backoff
 backtrace
 boolean


### PR DESCRIPTION
since spelling 4.2.1, the build fails with some python stack trace.
lock on a version that is known to work