### PR TITLE
fix flex installation instructions

### DIFF
--- a/integrations/symfony-bundle.rst
+++ b/integrations/symfony-bundle.rst
@@ -15,11 +15,11 @@ Installation
 Using Symfony Flex
 ------------------
 
-HttplugBundle is officially supported by `Symfony Flex`_ and available as the ``httplug`` alias.
+HttplugBundle has a `Symfony Flex`_ recipe that will set it up with default configuration:
 
 .. code-block:: bash
 
-    $ composer require httplug
+    $ composer require php-http/httplug-bundle
 
 Without Symfony Flex
 --------------------


### PR DESCRIPTION
the recipe got moved to contributed recipes, we no longer have an alias and need to use the package name.

fix https://github.com/php-http/httplug-flex-pack/issues/4