### PR TITLE
Add note about Guzzle throwing exceptions

### DIFF
--- a/clients/guzzle6-adapter.rst
+++ b/clients/guzzle6-adapter.rst
@@ -41,6 +41,8 @@ to the client::
         $guzzle = new GuzzleClient($config);
         // ...
         $adapter = new GuzzleAdapter($guzzle);
+        
+    If you pass a Guzzle instance to the adapter, make sure to configure Guzzle to not throw exceptions on HTTP error status codes, or this adapter will violate PSR-18.
 
 And use it to send synchronous requests::
 


### PR DESCRIPTION
I had an issue because Guzzle was throwing exceptions for 4xx and 5xx responses and this violates PSR-18. Via Google I stumbled upon https://github.com/php-http/guzzle6-adapter/issues/61#issuecomment-460232467 and found the cause, so the issue is fixed. However, nothing about this is mentioned in the docs, while using a custom Guzzle instance is. This PR adds the comment of https://github.com/php-http/guzzle6-adapter/pull/69 to the documentation so you don't have to Google when the guzzle-adapter is suddenly violating PSR-18.