### PR TITLE
Add Symfony Client entry

### DIFF
--- a/clients.rst
+++ b/clients.rst
@@ -16,6 +16,7 @@ interface and forwarding the calls to an HTTP client not implementing the interf
    clients/curl-client
    clients/socket-client
    clients/mock-client
+   clients/symfony-client
    clients/artax-adapter
    clients/buzz-adapter
    clients/cakephp-adapter
@@ -31,6 +32,7 @@ interface and forwarding the calls to an HTTP client not implementing the interf
    "``php-http/curl-client``", "Client", ":doc:`Docs </clients/curl-client>`, `Repo <https://github.com/php-http/curl-client>`__", "|curl_version| |curl_downloads| "
    "``php-http/socket-client``", "Client", ":doc:`Docs </clients/socket-client>`, `Repo <https://github.com/php-http/socket-client>`__", "|socket_version| |socket_downloads| "
    "``php-http/mock-client``", "Client", ":doc:`Docs </clients/mock-client>`, `Repo <https://github.com/php-http/mock-client>`__", "|mock_version| |mock_downloads| "
+   "``symfony/http-client``", "Client", ":doc:`Docs </clients/symfony-client>`, `Repo <https://github.com/symfony/http-client>`__", "|symfony_version| |symfony_downloads| "
    "``php-http/artax-adapter``", "Adapter", ":doc:`Docs </clients/artax-adapter>`, `Repo <https://github.com/php-http/artax-adapter>`__", "|artax_version| |artax_downloads| "
    "``php-http/buzz-adapter``", "Adapter", ":doc:`Docs </clients/buzz-adapter>`, `Repo <https://github.com/php-http/buzz-adapter>`__", "|buzz_version| |buzz_downloads| "
    "``php-http/cakephp-adapter``", "Adapter", ":doc:`Docs </clients/cakephp-adapter>`, `Repo <https://github.com/php-http/cakephp-adapter>`__", "|cakephp_version| |cakephp_downloads| "
@@ -74,6 +76,13 @@ HTTPlug use the ``provide`` section to tell composer that they do provide the cl
    :alt: Total Downloads
 .. |mock_version| image:: https://img.shields.io/github/release/php-http/mock-client.svg?style=flat-square
    :target: https://github.com/php-http/mock-client/releases
+   :alt: Latest Version
+
+.. |symfony_downloads| image:: https://img.shields.io/packagist/dt/symfony/http-client.svg?style=flat-square
+   :target: https://packagist.org/packages/symfony/http-client
+   :alt: Total Downloads
+.. |symfony_version| image:: https://img.shields.io/github/v/tag/symfony/http-client.svg?style=flat-square
+   :target: https://github.com/symfony/http-client/releases
    :alt: Latest Version
 
 .. |artax_downloads| image:: https://img.shields.io/packagist/dt/php-http/artax-adapter.svg?style=flat-square

--- a/clients/symfony-client.rst
+++ b/clients/symfony-client.rst
@@ -1,0 +1,37 @@
+Symfony Client
+==============
+
+An HTTPlug implementation from the `Symfony HttpClient`_.
+
+Installation
+------------
+
+To install the Symfony client, run:
+
+.. code-block:: bash
+
+    $ composer require symfony/http-client
+
+This client does not come with a PSR-7 implementation out of the box, so you have
+to install one as well. `Nyholm PSR-7`_ is supported natively:
+
+.. code-block:: bash
+
+    $ composer require nyholm/psr7
+
+.. include:: includes/install-discovery.inc
+
+Usage
+-----
+
+    use Symfony\Component\HttpClient\HttplugClient;
+
+    $symfonyClient = new HttplugClient();
+
+.. note::
+
+    Check the official `Symfony HttpClient`_ documentation for more details.
+
+.. _Symfony HttpClient: https://symfony.com/doc/current/components/http_client.html#httplug
+
+.. _Nyholm PSR-7: https://github.com/Nyholm/psr7/

--- a/discovery.rst
+++ b/discovery.rst
@@ -35,7 +35,7 @@ Strategies
 
 The package supports multiple discovery strategies and comes with two out-of-the-box:
 
-- A built-in strategy supporting the HTTPlug adapters, clients and factories (including Guzzle, Diactoros and Slim Framework)
+- A built-in strategy supporting the HTTPlug adapters, clients and factories (including Symfony, Guzzle, Diactoros and Slim Framework)
 - A strategy supporting the beta version of `Puli`_
 
 Strategies provide candidates of a type which gets evaluated by the discovery service.


### PR DESCRIPTION
Symfony implements Httplug natively in v4.4, let's tell about it.