### PR TITLE
Added documentation for option blacklisted_paths

### DIFF
--- a/plugins/cache.rst
+++ b/plugins/cache.rst
@@ -73,6 +73,9 @@ The third parameter to the ``CachePlugin`` constructor takes an array of options
 | ``cache_listeners``                   | ``[]``                                             | A array of classes implementing ``CacheListener`` to act on a         |
 |                                       |                                                    | response with information on its cache status.                        |
 +---------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------+
+| ``blacklisted_paths``                 | ``[]``                                             | A array of regular expressions to defined paths, that shall not be    |
+|                                       |                                                    | cached.                                                               |
++---------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------+
 
 
 .. note::


### PR DESCRIPTION
This is the documentation part of the cache-plugin blacklisted-paths option integration.