### PR TITLE
Added `laminas-diactoros`

### DIFF
--- a/clients/includes/install-message-factory.inc
+++ b/clients/includes/install-message-factory.inc
@@ -7,7 +7,7 @@ to install one as well (for example `Guzzle PSR-7`_):
 
 In order to provide full interoperability, message implementations are
 accessed through :ref:`factories <message-factory>`. Message factories for
-`Diactoros`_, `Guzzle PSR-7`_ and `Slim Framework`_ are available in the
+`Laminas Diactoros`_ (and its abandoned predecessor `Zend Diactoros`_), `Guzzle PSR-7`_ and `Slim Framework`_ are available in the
 :doc:`message </message>` component:
 
 .. code-block:: bash

--- a/clients/includes/install-message-factory.inc
+++ b/clients/includes/install-message-factory.inc
@@ -14,7 +14,7 @@ accessed through :ref:`factories <message-factory>`. Message factories for
 
     $ composer require php-http/message
 
-.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Guzzle PSR-7: https://github.com/guzzle/psr7
+.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Slim Framework: https://github.com/slimphp/Slim
 .. _Zend Diactoros: https://github.com/zendframework/zend-diactoros

--- a/clients/includes/install-message-factory.inc
+++ b/clients/includes/install-message-factory.inc
@@ -14,6 +14,7 @@ accessed through :ref:`factories <message-factory>`. Message factories for
 
     $ composer require php-http/message
 
-.. _Diactoros: https://github.com/zendframework/zend-diactoros
+.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Guzzle PSR-7: https://github.com/guzzle/psr7
 .. _Slim Framework: https://github.com/slimphp/Slim
+.. _Zend Diactoros: https://github.com/zendframework/zend-diactoros

--- a/httplug/users.rst
+++ b/httplug/users.rst
@@ -36,11 +36,11 @@ You can pick any of the clients or adapters :doc:`provided by PHP-HTTP </clients
 Popular choices are ``php-http/curl-client`` and ``php-http/guzzle6-adapter``.
 
 Many libraries also need a PSR-7 implementation and the PHP-HTTP message
-factories to create messages. The PSR-7 implementations are Zend's Diactoros, Guzzle's PSR-7 and Slim Framework's PSR-7 messages. Do one of the following:
+factories to create messages. The PSR-7 implementations are Zend's Diactoros (abandoned), Laminas Diactoros, Guzzle's PSR-7 and Slim Framework's PSR-7 messages. Do one of the following:
 
 .. code-block:: bash
 
-    $ composer require php-http/message zendframework/zend-diactoros
+    $ composer require php-http/message laminas/laminas-diactoros
 
 .. code-block:: bash
 

--- a/httplug/users.rst
+++ b/httplug/users.rst
@@ -36,7 +36,7 @@ You can pick any of the clients or adapters :doc:`provided by PHP-HTTP </clients
 Popular choices are ``php-http/curl-client`` and ``php-http/guzzle6-adapter``.
 
 Many libraries also need a PSR-7 implementation and the PHP-HTTP message
-factories to create messages. The PSR-7 implementations are Zend's Diactoros (abandoned), Laminas Diactoros, Guzzle's PSR-7 and Slim Framework's PSR-7 messages. Do one of the following:
+factories to create messages. The PSR-7 implementations are Laminas Diactoros (also still supports the abandoned Zend Diactoros), Guzzle's PSR-7 and Slim Framework's PSR-7 messages. Do one of the following:
 
 .. code-block:: bash
 

--- a/message/message-factory.rst
+++ b/message/message-factory.rst
@@ -135,7 +135,7 @@ It would make sense to also provide factories for the server side constructs
 to do that yet. Contributions are welcome if you want to define the
 ``ServerRequestFactory`` and ``UploadedFileFactory``.
 
-.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Guzzle PSR-7: https://github.com/guzzle/psr7
+.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Slim Framework: https://github.com/slimphp/Slim
 .. _Zend Diactoros: https://github.com/zendframework/zend-diactoros

--- a/message/message-factory.rst
+++ b/message/message-factory.rst
@@ -135,6 +135,7 @@ It would make sense to also provide factories for the server side constructs
 to do that yet. Contributions are welcome if you want to define the
 ``ServerRequestFactory`` and ``UploadedFileFactory``.
 
-.. _Diactoros: https://github.com/zendframework/zend-diactoros
+.. _Laminas Diactoros: https://github.com/laminas/laminas-diactoros
 .. _Guzzle PSR-7: https://github.com/guzzle/psr7
 .. _Slim Framework: https://github.com/slimphp/Slim
+.. _Zend Diactoros: https://github.com/zendframework/zend-diactoros

--- a/message/message-factory.rst
+++ b/message/message-factory.rst
@@ -30,7 +30,7 @@ The `php-http/message-factory` package defines interfaces for PSR-7 factories in
 - ``StreamFactory``
 - ``UriFactory``
 
-Implementations of the interfaces above for `Diactoros`_, `Guzzle PSR-7`_ and the `Slim Framework`_ can be found in ``php-http/message``.
+Implementations of the interfaces above for `Laminas Diactoros`_ (and its abandoned predecessor `Zend Diactoros`_), `Guzzle PSR-7`_ and the `Slim Framework`_ can be found in ``php-http/message``.
 
 Usage
 -----

--- a/spelling_word_list.txt
+++ b/spelling_word_list.txt
@@ -14,6 +14,7 @@ Elasticsearch
 fallback
 GitHub
 hotfix
+Laminas
 Liskov
 Symfony
 HTTPlug


### PR DESCRIPTION
#### What's in this PR?

- Moved zend-diactoros to the end of lists
- Changed installation example to `laminas-diactoros`
- Marked zend-diactoros as abandoned where possible


#### Why?

As of the end of 2019, [zendframework got abandoned and laminas was released](https://framework.zend.com/blog/2020-01-24-laminas-launch).

Thus, [laminas-diactoros](https://github.com/laminas/laminas-diactoros) replaced diactoros of zendframework.

I am not sure how you guys want to handle that replace. I've created a PR in https://github.com/php-http/discovery/pull/169 in order to add support for laminas.

Should we drop the zendframework part totally from the documentation or keep it as the package still supports zendframework?

Would love to get some feedback here.
