### PR TITLE
Added `strict` option for RedirectPlugin

### DIFF
--- a/plugins/redirect.rst
+++ b/plugins/redirect.rst
@@ -42,3 +42,9 @@ request.
 
 Whether to follow the default direction on the multiple redirection status code 300. If set to
 false, a status of 300 will raise the ``Http\Client\Common\Exception\MultipleRedirectionException``.
+
+``strict``: bool (default: false)
+
+When set to ``true``, 300, 301 and 302 status codes will not modify original request's method and 
+body on consecutive requests. E. g. POST redirect requests are sent as POST requests instead of 
+POST redirect requests are sent as GET requests.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/php-http/client-common/pull/208 
| License         | MIT


#### What's in this PR?

Documenting `strict` option for RedirectPlugin

Strict RFC compliant redirects mean that POST redirect requests are sent as POST requests vs. doing what most browsers do which is redirect POST requests with GET requests.

#### Example Usage

``` php
$plugins = $plugins ?? [
    new RedirectPlugin(['strict' => true]),
];

$httpClient = (new PluginClientFactory())->createClient(
    Psr18ClientDiscovery::find(),
    $plugins
);
```
