### PR TITLE
Fix broken link to PSR-18 in index

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -306,7 +306,8 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 rst_epilog = """
-.. _PSR-7: http://www.php-fig.org/psr/psr-7
+.. _PSR-7: https://www.php-fig.org/psr/psr-7
+.. _PSR-18: https://www.php-fig.org/psr/psr-18
 .. _Composer: https://getcomposer.org
 .. _HttplugBundle: https://github.com/php-http/HttplugBundle
 """

--- a/discovery.rst
+++ b/discovery.rst
@@ -291,4 +291,3 @@ and that it is not used by the Discovery Service by default. It is simply
 provided as a convenient option when writing tests.
 
 .. _PSR-17: http://www.php-fig.org/psr/psr-17
-.. _PSR-18: http://www.php-fig.org/psr/psr-18


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

`index.rst` refers to a link to PSR-18, but does not actually provide that link.

Let's:
- move the link to PSR-18 to the epilog so that both `discovery.rst` and `index.rst` link to PSR-18 properly
- change the link to PSR-17 to HTTPS, because it's 2021 :p
#### Why?

Link's broken, gotta fix it.