### PR TITLE
Correct php-http/httplug version

### DIFF
--- a/httplug/library-developers.rst
+++ b/httplug/library-developers.rst
@@ -98,7 +98,7 @@ Putting it all together your final ``composer.json`` is much likely to look simi
         "require": {
             "psr/http-message": "^1.0",
             "psr/http-client-implementation": "^1.0",
-            "php-http/httplug": "^1.0",
+            "php-http/httplug": "^2.0",
             "php-http/message-factory": "^1.0",
             "php-http/discovery": "^1.0"
         },


### PR DESCRIPTION
Correct php-http/httplug version form "^1.0" to "^2.0" to reflect an installable Your Final ``composer.json``

| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

When using the example on this page you'll get:
```bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - php-http/mock-client[dev-master, 1.5.0] require php-http/httplug ^2.0 -> found php-http/httplug[dev-master, v2.0.0, 2.1.0, 2.2.0, 2.x-dev (alias of dev-master)] but it conflicts with your root composer.json require (^1.0).
    - php-http/mock-client 1.x-dev is an alias of php-http/mock-client dev-master and thus requires it to be installed too.
    - Root composer.json requires psr/http-client-implementation ^1.0 -> satisfiable by php-http/mock-client[dev-master, 1.5.0, 1.x-dev (alias of dev-master)].
```

#### Why?

This makes the example directly usable
