### PR TITLE
Update bundle config reference for error plugin

### DIFF
--- a/integrations/symfony-bundle.rst
+++ b/integrations/symfony-bundle.rst
@@ -322,6 +322,8 @@ You can configure many of the plugins directly on the client:
             acme:
                 factory: 'httplug.factory.guzzle6'
                 plugins:
+                    - error:
+                        only_server_exception: true
                     - add_host:
                         host: "http://localhost:8000"
                     - header_defaults:

--- a/integrations/symfony-bundle.rst
+++ b/integrations/symfony-bundle.rst
@@ -477,8 +477,7 @@ List of Services
 +-------------------------------------+-------------------------------------------------------------------------+
 | | ``httplug.plugin.content_length`` | | These are plugins that are enabled by default.                        |
 | | ``httplug.plugin.decoder``        | | These services are private and should only be used to configure       |
-| | ``httplug.plugin.error``          | | clients or other services.                                            |
-| | ``httplug.plugin.logger``         |                                                                         |
+| | ``httplug.plugin.logger``         | | clients or other services.                                            |
 | | ``httplug.plugin.redirect``       |                                                                         |
 | | ``httplug.plugin.retry``          |                                                                         |
 | | ``httplug.plugin.stopwatch``      |                                                                         |
@@ -486,7 +485,7 @@ List of Services
 | | ``httplug.plugin.cache``          | | These are plugins that are disabled by default and only get           |
 | | ``httplug.plugin.cookie``         | | activated when configured.                                            |
 | | ``httplug.plugin.history``        | | These services are private and should only be used to configure       |
-|                                     | | clients or other services.                                            |
+| | ``httplug.plugin.error``          | | clients or other services.                                            |
 +-------------------------------------+-------------------------------------------------------------------------+
 
 \* *These services are always an alias to another service. You can specify your own service or leave the default, which is the same name with `.default` appended.*

--- a/integrations/symfony-full-configuration.rst
+++ b/integrations/symfony-full-configuration.rst
@@ -67,6 +67,8 @@ This page shows an example of all configuration values provided by the bundle.
                 retry: 1
             stopwatch:
                 stopwatch: 'debug.stopwatch'
+            error:
+                only_server_exception: false
 
         profiling:
             enabled: true # Defaults to kernel.debug

--- a/integrations/symfony-full-configuration.rst
+++ b/integrations/symfony-full-configuration.rst
@@ -68,6 +68,7 @@ This page shows an example of all configuration values provided by the bundle.
             stopwatch:
                 stopwatch: 'debug.stopwatch'
             error:
+                enabled: false
                 only_server_exception: false
 
         profiling:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | ---
| Documentation   | https://github.com/php-http/HttplugBundle/pull/419
| License         | MIT


#### What's in this PR?

Updates the Symfony config reference for the added error plugin configuration

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [X] Documentation pull request created (if not simply a bugfix)

