### PR TITLE
docs: remove old version constraint to install php-http/client-common

### DIFF
--- a/components/client-common.rst
+++ b/components/client-common.rst
@@ -6,7 +6,7 @@ Include them in your project with composer:
 
 .. code-block:: bash
 
-    composer require php-http/client-common "^1.0"
+    composer require php-http/client-common
 
 HttpMethodsClient
 -----------------


### PR DESCRIPTION
I think it is best to let composer find out the correct version.
Or do i miss something here?