### PR TITLE
Fix typo in mock client docs

### DIFF
--- a/clients/mock-client.rst
+++ b/clients/mock-client.rst
@@ -161,7 +161,7 @@ To conditionally return a response when a request is matched::
 
             // $requestMatcher is an instance of Http\Message\RequestMatcher
 
-            $response = $this->createMock(ResponseInterface:class);
+            $response = $this->createMock(ResponseInterface::class);
             $client->on($requestMatcher, $response);
 
             // $request is an instance of Psr\Http\Message\RequestInterface


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| Documentation   |
| License         | MIT


#### What's in this PR?

This PR fixes a small typo in the code example for using the Mock client.


#### Why?

Because copy and pasting of the code example results in invalid code.
